### PR TITLE
server_axum: Move addr to serve fn, add listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Using this route in a standalone server with only an XML-RPC endpoint is straigh
 ```rust
 use dxr_server::Server;
 
-let server = Server::from_route("0.0.0.0:3000".parse().unwrap(), route);
-server.serve().await.unwrap();
+let server = Server::from_route(route);
+server.serve("0.0.0.0:3000".parse().unwrap()).await.unwrap();
 ```
 
 The `dxr_tests/examples/server.rs` file contains an implementation of a simple server binary, which

--- a/dxr_tests/examples/server.rs
+++ b/dxr_tests/examples/server.rs
@@ -70,7 +70,10 @@ async fn main() {
         .add_method("add", Box::new(adder_handler as HandlerFn))
         .build();
 
-    let server = Server::from_route("0.0.0.0:3000".parse().unwrap(), route);
+    let server = Server::from_route(route);
 
-    server.serve().await.expect("Failed to run server.")
+    server
+        .serve("0.0.0.0:3000".parse().unwrap())
+        .await
+        .expect("Failed to run server.")
 }

--- a/dxr_tests/tests/adder.rs
+++ b/dxr_tests/tests/adder.rs
@@ -19,10 +19,10 @@ async fn adder() {
         .add_method("add", Box::new(adder_handler as HandlerFn))
         .build();
 
-    let mut server = Server::from_route("0.0.0.0:3000".parse().unwrap(), route);
+    let mut server = Server::from_route(route);
     let trigger = server.shutdown_trigger();
 
-    let serve = tokio::spawn(server.serve());
+    let serve = tokio::spawn(server.serve("0.0.0.0:3000".parse().unwrap()));
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let calls = || async {

--- a/dxr_tests/tests/echo_any.rs
+++ b/dxr_tests/tests/echo_any.rs
@@ -31,10 +31,10 @@ async fn echo() {
         .add_method("echo", Box::new(echo_handler as HandlerFn))
         .build();
 
-    let mut server = Server::from_route("0.0.0.0:3000".parse().unwrap(), route);
+    let mut server = Server::from_route(route);
     let trigger = server.shutdown_trigger();
 
-    let serve = tokio::spawn(server.serve());
+    let serve = tokio::spawn(server.serve("0.0.0.0:3000".parse().unwrap()));
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let calls = || async {

--- a/dxr_tests/tests/echo_one.rs
+++ b/dxr_tests/tests/echo_one.rs
@@ -32,10 +32,10 @@ async fn echo_one() {
         .add_method("echo", Box::new(echo_handler as HandlerFn))
         .build();
 
-    let mut server = Server::from_route("0.0.0.0:3000".parse().unwrap(), route);
+    let mut server = Server::from_route(route);
     let trigger = server.shutdown_trigger();
 
-    let serve = tokio::spawn(server.serve());
+    let serve = tokio::spawn(server.serve("0.0.0.0:3000".parse().unwrap()));
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let calls = || async {


### PR DESCRIPTION
First of all: Thanks for creating the library, really happy with it so far 💯 

This moves the addr out of the arguments for `from_route` and into `serve`.
It also adds a new fn to start the server: `serve_listener` which allows starting the server with an existing `TcpListener`.

`serve` now creates the `TcpListener` (and panics in the same way `bind` would've panic'ed) and calls `serve_listener`.

I know this is a breaking change. Personally I think the addr belongs into `serve` but, happy to make any changes if you prefer a different solution.