### PR TITLE
derive: fix compilation error if user define its own Result type

### DIFF
--- a/dxr/tests/derive.rs
+++ b/dxr/tests/derive.rs
@@ -5,6 +5,7 @@ fn try_build_pass() {
     t.pass("tests/trybuild/moo.rs");
     t.pass("tests/trybuild/appendix.rs");
     t.pass("tests/trybuild/recursive.rs");
+    t.pass("tests/trybuild/custom_result_type.rs");
     t.pass("tests/trybuild/ownership.rs");
     t.pass("tests/trybuild/collections.rs");
 }

--- a/dxr/tests/trybuild/custom_result_type.rs
+++ b/dxr/tests/trybuild/custom_result_type.rs
@@ -1,0 +1,10 @@
+use dxr::{TryFromValue, TryToValue};
+
+type Result<T> = std::result::Result<T, ()>;
+
+#[derive(TryFromValue, TryToValue)]
+pub struct Array {
+    array: [i32; 4],
+}
+
+fn main() {}

--- a/dxr_derive/src/lib.rs
+++ b/dxr_derive/src/lib.rs
@@ -145,7 +145,7 @@ pub fn try_from_value(input: TokenStream) -> TokenStream {
 
     let impl_block = quote! {
         impl #impl_generics #dxr::TryFromValue for #name #ty_generics #where_clause {
-            fn try_from_value(value: &#dxr::Value) -> Result<#name #ty_generics, #dxr::DxrError> {
+            fn try_from_value(value: &#dxr::Value) -> ::std::result::Result<#name #ty_generics, #dxr::DxrError> {
                 use ::std::collections::HashMap;
                 use ::std::string::String;
                 use #dxr::{Value, DxrError};
@@ -258,7 +258,7 @@ pub fn try_to_value(input: TokenStream) -> TokenStream {
 
     let impl_block = quote! {
         impl #impl_generics #dxr::TryToValue for #name #ty_generics #where_clause {
-            fn try_to_value(&self) -> Result<#dxr::Value, #dxr::DxrError> {
+            fn try_to_value(&self) -> ::std::result::Result<#dxr::Value, #dxr::DxrError> {
                 use ::std::collections::HashMap;
                 use ::std::string::String;
                 use #dxr::Value;


### PR DESCRIPTION
When using the `TryFromValue` and `TryToValue` macros in a file where a custom `Result` is defined (in my case `
type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;`) the macro doesn't work anymore and create a compilation error.

The Result seems to be common pattern and I think it should not break the macrso (https://doc.rust-lang.org/rust-by-example/error/result/result_alias.html )