### PR TITLE
deps: bump quick-xml dependency from 0.30 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "serde",

--- a/dxr/Cargo.toml
+++ b/dxr/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["derive", "i8", "nil"]
 dxr_derive = { workspace = true, optional = true }
 base64 = "0.22"
 chrono = { version = "0.4.19", features = ["std"], default-features = false }
-quick-xml = { version = "0.30", features = ["serialize"] }
+quick-xml = { version = "0.31", features = ["serialize"] }
 serde = { version = "1.0.104", features = ["derive"] }
 thiserror = "1.0.30"
 


### PR DESCRIPTION
This compiles but fails tests. There are assertion failures internal to quick-xml code that I don't understand (see CI output once it runs).

Maybe @Mingun has an idea what's going on? I suppose our custom Deserializer for `Value` is the cause, but I can't tell *why*:

https://github.com/ironthree/dxr/blob/quick-xml-0.31/dxr/src/values/ser_de.rs#L94