### PR TITLE
upgrade quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,3 @@ dxr_server = { path = "./dxr_server", version = "0.7.0-dev" }
 codegen-units = 1
 lto = true
 opt-level = 3
-

--- a/dxr/Cargo.toml
+++ b/dxr/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["derive", "i8", "nil"]
 dxr_derive = { workspace = true, optional = true }
 base64 = "0.22"
 chrono = { version = "0.4.19", features = ["std"], default-features = false }
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.37.0", features = ["serialize"] }
 serde = { version = "1.0.104", features = ["derive"] }
 thiserror = "1.0.30"
 

--- a/dxr/src/xml.rs
+++ b/dxr/src/xml.rs
@@ -1,5 +1,5 @@
 use quick_xml::de::DeError;
-use quick_xml::se::{QuoteLevel, Serializer};
+use quick_xml::se::{QuoteLevel, Serializer, SeError};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// implementations.
 ///
 /// This should be a drop-in replacement for [`quick_xml::se::to_string`].
-pub fn serialize_xml<T>(value: &T) -> Result<String, DeError>
+pub fn serialize_xml<T>(value: &T) -> Result<String, SeError>
 where
     T: Serialize,
 {


### PR DESCRIPTION
Pulling in [some bugfixes](https://github.com/tafia/quick-xml/blob/v0.37.0/Changelog.md#0370----2024-10-27) since the previous version, adjusting for a small API change on serialization.

The current crates-io version of dxr still uses quick-xml 0.30.x, which has a bug in its `expand_empty_elements` behavior that we're hitting in [ros-core-rs](https://github.com/patwie/ros-core-rs) (which depends on dxr). It would be really cool if you could do a crates.io release which has a newer quick-xml, so we could depend on that one :)