### PR TITLE
allow other crates to create Value of empty Struct

### DIFF
--- a/dxr/src/values/types.rs
+++ b/dxr/src/values/types.rs
@@ -82,6 +82,7 @@ impl Value {
         Value::new(Type::Base64(value))
     }
 
+    /// constructor for nested structures
     pub fn structure(value: Struct) -> Value {
         Value::new(Type::Struct { members: value.members })
     }
@@ -158,6 +159,7 @@ impl Type {
     }
 }
 
+/// Nested structure
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename = "struct")]
 pub struct Struct {
@@ -171,6 +173,7 @@ impl Struct {
         Struct { members }
     }
 
+    /// Creates an empty struct with no members.
     pub fn empty() -> Struct {
         Struct { members: vec![]}
     }


### PR DESCRIPTION
follow-up to my issue
- https://github.com/ironthree/dxr/issues/24

If you merge this, it'd be great if you could also do a point release on crates.io, so we can use it [from ros-core-rs](https://github.com/PatWie/ros-core-rs/pull/9).