### PR TITLE
server: log on missing handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "dxr",
  "http",
  "hyper",
+ "log",
  "thiserror",
  "tokio",
 ]
@@ -790,9 +791,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchit"

--- a/dxr_server/Cargo.toml
+++ b/dxr_server/Cargo.toml
@@ -15,11 +15,11 @@ repository.workspace = true
 dxr.workspace = true
 async-trait = "0.1.53"
 http = "1.0"
+log = "0.4"
 
 # axum support
 axum = { version = "0.7", optional = true }
 hyper = { version = "1.0", optional = true }
-log = "0.4"
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "1.14", features = ["sync"], optional = true }
 

--- a/dxr_server/Cargo.toml
+++ b/dxr_server/Cargo.toml
@@ -19,9 +19,9 @@ http = "1.0"
 # axum support
 axum = { version = "0.7", optional = true }
 hyper = { version = "1.0", optional = true }
+log = "0.4"
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "1.14", features = ["sync"], optional = true }
-log = "0.4.26"
 
 [features]
 default = []

--- a/dxr_server/Cargo.toml
+++ b/dxr_server/Cargo.toml
@@ -21,6 +21,7 @@ axum = { version = "0.7", optional = true }
 hyper = { version = "1.0", optional = true }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "1.14", features = ["sync"], optional = true }
+log = "0.4.26"
 
 [features]
 default = []

--- a/dxr_server/src/lib.rs
+++ b/dxr_server/src/lib.rs
@@ -71,7 +71,7 @@ pub async fn server(handlers: HandlerMap, body: &str, headers: HeaderMap) -> (St
                     let handler = match handlers.get(name.as_str()) {
                         Some(handler) => handler,
                         None => {
-                            log::warn!("Missing rpc handler for {}", name);
+                            log_no_handler(&name);
                             results.push(Err(Fault::new(404, String::from("Unknown method."))));
                             continue;
                         },
@@ -95,7 +95,7 @@ pub async fn server(handlers: HandlerMap, body: &str, headers: HeaderMap) -> (St
     let handler = match handlers.get(call.name()) {
         Some(handler) => handler,
         None => {
-            log::warn!("Missing rpc handler for {}", call.name());
+            log_no_handler(call.name());
             return fault_to_response(404, "Unknown method.");
         },
     };
@@ -131,4 +131,9 @@ fn fault_to_response(code: i32, string: &str) -> (StatusCode, HeaderMap, String)
         Ok(fault) => (StatusCode::OK, response_headers(), fault),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, response_headers(), error.to_string()),
     }
+}
+
+/// Write a debug log on missing rpc handler.
+fn log_no_handler(method: &str) {
+    log::debug!("No handler registered for method: {method}")
 }

--- a/dxr_server/src/lib.rs
+++ b/dxr_server/src/lib.rs
@@ -71,6 +71,7 @@ pub async fn server(handlers: HandlerMap, body: &str, headers: HeaderMap) -> (St
                     let handler = match handlers.get(name.as_str()) {
                         Some(handler) => handler,
                         None => {
+                            log::warn!("Missing rpc handler for {}", name);
                             results.push(Err(Fault::new(404, String::from("Unknown method."))));
                             continue;
                         },
@@ -93,7 +94,10 @@ pub async fn server(handlers: HandlerMap, body: &str, headers: HeaderMap) -> (St
 
     let handler = match handlers.get(call.name()) {
         Some(handler) => handler,
-        None => return fault_to_response(404, "Unknown method."),
+        None => {
+            log::warn!("Missing rpc handler for {}", call.name());
+            return fault_to_response(404, "Unknown method.");
+        },
     };
 
     let response = match handler.handle(&call.params(), headers).await {


### PR DESCRIPTION
Hi,

first of all thank you for creating and maintaining this very helpful project!

This PR adds a log message to dxr_server on unhandled method calls. 
I used the rust standard log crate for that purpose. It's also used for example in reqwest so it's already in the dependency tree.

I find those logs very useful when working with the server and a not fully known counterpart.

Thank you in advance for checking the PR!